### PR TITLE
 Use throttle rather than debounce under the hood

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-sessions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Redux action creators for storing session state",
   "main": "lib/index.js",
   "scripts": {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,5 +1,5 @@
 import { saveSessionState } from './persistenceHelpers'
-import { debounce } from 'lodash'
+import { throttle } from 'lodash'
 
 const DEFAULT_DEBOUNCE_INTERVAL = 500
 
@@ -15,7 +15,7 @@ function enhancer ({ persist=true, debounceInterval=DEFAULT_DEBOUNCE_INTERVAL }=
         if (!state.sessions) throw new Error('redux-sessions: error when attempting to save state. Did you remember to attach the reducer at key `sessions`?')
         return saveSessionState(state.sessions)
       }
-      store.subscribe(debounce(persistState, debounceInterval))
+      store.subscribe(throttle(persistState, debounceInterval))
       return store
     }
   }


### PR DESCRIPTION
To make sure subscription events are called upfront.